### PR TITLE
Tell circleci which NodeJS version to use

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 6.9.4


### PR DESCRIPTION
Chose v6 for compatibility with people using this library.

`.nvmrc` does indicate v8, but that's mostly a byproduct of wanting `npm` v5.