### PR TITLE
stop() now returns the labels and time for re-usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Starts counting time using `process.hrtime`.
 
 #### stopTimer(labels)
 * **labels** : Labels to apply to the observation. They will be merged with the labels given to `startTimer` (if any). Defaults to `{}`
+* returns: { labels, elapsed }. This is in case you want to re-use those values in something else than prometheus itself.
+** labels: the result of combining labels given to `startTimer` and `stopTimer`
+** elapsed: the time measured by the timer, in the correct unit.
 
 Stops the timer and record the elapsed time in seconds divided by `factor`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare function startTimer(
 ): stopTimer
 declare function stopTimer(
   labels?: PromClient.labelValues
-): void
+): { elapsed: number, labels: PromClient.labelValues }
 
 declare namespace startTimer {
 }

--- a/index.js
+++ b/index.js
@@ -13,5 +13,6 @@ module.exports = function startTimer(metric, factor = 1, startLabels = {}) {
 
     const labels = Object.assign({}, startLabels, endLabels)
     metric.observe(labels, elapsed)
+    return { elapsed, labels }
   }
 }

--- a/test.js
+++ b/test.js
@@ -78,9 +78,19 @@ describe('startTimer', () => {
 
     it('applies both start and end labels', () => {
       const metric = new MetricMock()
-      const stop = startTimer(metric, null, { start: 'yup' })
+      const stop = startTimer(metric, undefined, { start: 'yup' })
       stop({ end: 'already' })
       expect(metric.observed[0]).to.deep.equal({ start: 'yup', end: 'already' })
+    })
+
+    it('returns the elapsed time and labels', () => {
+      const metric = new MetricMock()
+      const stop = startTimer(metric, undefined, { start: 'yup' })
+      const result = stop({ end: 'already' })
+      expect(result).to.deep.equal({
+        elapsed: metric.observed[1],
+        labels: metric.observed[0]
+      })
     })
   })
 })


### PR DESCRIPTION
This is used by one of our closed-source projects to log the time it took to process an HTTP request.

Labels aren't strictly needed but I would rather include them for nothing rather than introduce a breaking change further down the line.

`null` to `undefined` is because passing `null` result in a measurement of NaN. We should probably fix that someday 🌚 .